### PR TITLE
JSON schema fix

### DIFF
--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": true,
   "definitions": {
     "AttributeBooleanType": {
@@ -25,71 +25,69 @@
       "type": "object"
     },
     "EventType": {
-      "properties": {
-        "ocel:id": {
-          "$ref": "#/definitions/AttributeStringType"
-        },
-        "ocel:activity": {
-          "$ref": "#/definitions/AttributeStringType"
-        },
-        "ocel:timestamp": {
-          "$ref": "#/definitions/AttributeDateType"
-        },
-        "ocel:vmap": {
-          "items": {
-            "$ref": "#/definitions/ValueMappingType"
+      "patternProperties": {
+        "(.*?)": {
+          "type": "object",
+          "properties": {
+            "ocel:id": {
+              "$ref": "#/definitions/AttributeStringType"
+            },
+            "ocel:activity": {
+              "$ref": "#/definitions/AttributeStringType"
+            },
+            "ocel:timestamp": {
+              "$ref": "#/definitions/AttributeDateType"
+            },
+            "ocel:vmap": {
+              "items": {
+                "$ref": "#/definitions/ValueMappingType"
+              },
+              "type": "object"
+            },
+            "ocel:omap": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AttributeStringType"
+              }
+            }
           },
-          "type": "object"
-        },
-        "ocel:omap": {
-          "type": "array"
+          "required": [
+            "ocel:activity",
+            "ocel:timestamp",
+            "ocel:omap",
+            "ocel:vmap"
+          ]
         }
-      },
-      "required": [
-        "ocel:id",
-        "ocel:activity",
-        "ocel:timestamp",
-        "ocel:omap",
-        "ocel:vmap"
-      ],
-      "type": "object"
+      }
     },
     "ObjectType": {
-      "properties": {
-        "ocel:id": {
-          "$ref": "#/definitions/AttributeStringType"
-        },
-        "ocel:type": {
-          "$ref": "#/definitions/AttributeStringType"
-        },
-        "ocel:ovmap": {
-          "items": {
-            "$ref": "#/definitions/ValueMappingType"
+      "type": "object",
+      "patternProperties": {
+        "(.*?)": {
+          "type": "object",
+          "properties": {
+            "ocel:type": {
+              "$ref": "#/definitions/AttributeStringType"
+            },
+            "ocel:ovmap": {
+              "$ref": "#/definitions/ValueMappingType"
+            }
           },
-          "type": "object"
+          "required": [
+            "ocel:type",
+            "ocel:ovmap"
+          ]
         }
-      },
-      "required": [
-        "ocel:id",
-        "ocel:type",
-        "ocel:ovmap"
-      ],
-      "type": "object"
+      }
     }
   },
   "description": "Schema for the JSON-OCEL implementation",
   "properties": {
     "ocel:events": {
-      "items": {
-        "$ref": "#/definitions/EventType"
-      },
-      "type": "object"
+      "$ref": "#/definitions/EventType"
     },
     "ocel:objects": {
-      "items": {
-        "$ref": "#/definitions/ObjectMappingType"
-      },
-      "type": "object"
+      "$ref": "#/definitions/ObjectType"
     }
   },
   "type": "object"


### PR DESCRIPTION
Hi, this was the problem with the json schema. I made the least amount of changes to make it validate correctly for the current version of the ocel standard.
## Sample
I wrote a small script to show the differences between commits:
```Python
import ocel
logs = ['min.jsonocel', 'min-e2-invalid.jsonocel', 'min-i2-invalid.jsonocel', 'min-empty.jsonocel']
validations = ['schema-current.json', 'schema-new.json']

for log in logs:
        for schema in validations:
                print(f'Log: {log} against Schema: {schema} --> {ocel.validate(log, schema)}')

```
Logs:
- min.jsonocel: same as in current repository
- min-e2-invalid.jsonocel: min.jsonocel with the activity property removed from event 2
- min-i2-invalid.jsonocel: min.jsonocel with the object type property removed from item2
- min-empty.jsonocel: min.jsonocel with all event and object instances being empty

Output:
> Log: min.jsonocel against Schema: schema-current.json --> True
> Log: min.jsonocel against Schema: schema-new.json --> True
> Log: min-e2-invalid.jsonocel against Schema: schema-current.json --> True
> Log: min-e2-invalid.jsonocel against Schema: schema-new.json --> False
> Log: min-i2-invalid.jsonocel against Schema: schema-current.json --> True
> Log: min-i2-invalid.jsonocel against Schema: schema-new.json --> False
> Log: min-empty.jsonocel against Schema: schema-current.json --> True
> Log: min-empty.jsonocel against Schema: schema-new.json --> False

## Hint
Although this change fixes the problem, it shows how unconventional the use of the current standard is (eg. using properties of ocel:events to store event types and having to use "(.*?)" as a patterned property). I would consider changing the type of ocel:events/objects to an array and including the id of the event/object inside the event type. This would mean many changes though, especially when it comes to importing currently available jsonocel logs and making sure all parts of the interface works. 

It is also important to note that the current schema does not require any ocel:global-object/event/log reference which would make most of the interface not usable. Full adherance to the RFC3339 date-time standard might also be something to add.

If you need anything else, let me know.